### PR TITLE
profile api 작성

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,9 +37,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    # gradle bootBuildImage를 이용해 이미지를 만들고 원격 저장소에 Push
-    - name: Build Image with Gradle and Push to DockerHub
-      run: ./gradlew bootBuildImage
+    # gradle Jib를 이용해 이미지를 만들고 원격 저장소에 Push
+    - name: Setup Jib with Gradle
+      run: ./gradlew jib
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,19 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.4'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 group = 'com.capstone'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
+
+jib {
+    to {
+        image='wanf-server'
+        tags=['0.4']
+    }
+}
 
 configurations {
     compileOnly {

--- a/src/main/java/com/capstone/wanf/major/domain/entity/repo/MajorRepository.java
+++ b/src/main/java/com/capstone/wanf/major/domain/entity/repo/MajorRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.wanf.major.domain.entity.repo;
+
+import com.capstone.wanf.major.domain.entity.Major;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MajorRepository extends JpaRepository<Major, Long> {
+}

--- a/src/main/java/com/capstone/wanf/major/service/MajorService.java
+++ b/src/main/java/com/capstone/wanf/major/service/MajorService.java
@@ -1,0 +1,21 @@
+package com.capstone.wanf.major.service;
+
+import com.capstone.wanf.major.domain.entity.Major;
+import com.capstone.wanf.major.domain.entity.repo.MajorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class MajorService {
+    private final MajorRepository majorRepository;
+
+    public Major findById(Long id){
+        Major major = majorRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "선택한 전공이 존재하지 않습니다."));
+
+        return major;
+    }
+
+}

--- a/src/main/java/com/capstone/wanf/profile/controller/ProfileController.java
+++ b/src/main/java/com/capstone/wanf/profile/controller/ProfileController.java
@@ -1,0 +1,37 @@
+package com.capstone.wanf.profile.controller;
+
+import com.capstone.wanf.profile.domain.entity.Profile;
+import com.capstone.wanf.profile.dto.request.ProfileRequest;
+import com.capstone.wanf.profile.service.ProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ProfileController {
+    private final ProfileService profileService;
+
+    @GetMapping("/profiles/{id}")
+    public ResponseEntity<Profile> findById(@PathVariable(name = "id") Long id) {
+        Profile profile = profileService.findById(id);
+
+        return ResponseEntity.ok(profile);
+    }
+
+    @PostMapping("/profiles")
+    public ResponseEntity<Profile> save(@Valid @ModelAttribute ProfileRequest profileRequest) {
+        Profile profile = profileService.save(profileRequest);
+
+        return ResponseEntity.ok(profile);
+    }
+
+    @PatchMapping("/profiles/{id}")
+    public ResponseEntity<Profile> updateField(@PathVariable(name = "id") Long id, @Valid @ModelAttribute ProfileRequest profileRequest) {
+        Profile profile = profileService.update(id, profileRequest);
+
+        return ResponseEntity.ok(profile);
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/Gender.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/Gender.java
@@ -1,0 +1,14 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE("남성"),FEMALE("여성");
+
+    private final String gender;
+
+    Gender(String gender) {
+        this.gender = gender;
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/Goal.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/Goal.java
@@ -1,0 +1,19 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Goal {
+    TOP_OF_THE_MAJOR("과탑"),
+    MAKING_FRIENDS("친목"),
+    AREA_OF_INTEREST("관심분야"),
+    JUST_TAKING_CLASS("그냥"),
+    GRADUATE("졸업"),
+    CAREER_DISCOVERY("진로 탐색");
+
+    private final String detail;
+
+    Goal(String detail) {
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/MBTI.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/MBTI.java
@@ -1,0 +1,29 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MBTI {
+    ISTJ("현실주의자"),
+    ISTP("장인"),
+    INFJ("옹호자"),
+    INTJ("전략가"),
+    ISFJ("수호자"),
+    ISFP("모험가"),
+    INFP("중재자"),
+    INTP("논리술사"),
+    ESTJ("경영가"),
+    ESFP("연예인"),
+    ENFP("활동가"),
+    ENTP("변론가"),
+    ESFJ("집정관"),
+    ESTP("사업가"),
+    ENFJ("선도자"),
+    ENTJ("통솔자");
+
+    private final String detail;
+
+    MBTI(String detail) {
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/Personality.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/Personality.java
@@ -1,0 +1,21 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Personality {
+    SILENT("조용한"),
+    BRIGHT("밝은"),
+    RELAXED("느긋한"),
+    EFFICIENCY("효율중시"),
+    LEADERSHIP("리더십 있는"),
+    METICULOUSNESS("꼼꼼한"),
+    BRAVERY("명량한");
+
+
+    private final String detail;
+
+    Personality(String detail) {
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/Profile.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/Profile.java
@@ -1,0 +1,75 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import com.capstone.wanf.common.entity.BaseTimeEntity;
+import com.capstone.wanf.major.domain.entity.Major;
+import com.capstone.wanf.profile.dto.request.ProfileRequest;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "profile")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Profile extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "student_Id", nullable = false)
+    private int studentId;
+
+    @Column(name = "age")
+    private int age;
+
+    @Column(name = "contact", columnDefinition = "TEXT")
+    private String contact;
+
+    @Enumerated(EnumType.STRING)
+    private ProfileImage profileImage;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private MBTI mbti;
+
+    @Enumerated(EnumType.STRING)
+    @ElementCollection
+    private List<Personality> personalities;
+
+    @Enumerated(EnumType.STRING)
+    @ElementCollection
+    private List<Goal> goals;
+
+    @OneToOne
+    @JoinColumn(name = "major_id", referencedColumnName = "id")
+    private Major major;
+
+    public void update(ProfileRequest profileRequest) {
+        this.profileImage = profileRequest.getProfileImage();
+
+        this.nickname = profileRequest.getNickname();
+
+        this.age = profileRequest.getAge();
+
+        this.goals = profileRequest.getGoals();
+
+        this.gender = profileRequest.getGender();
+
+        this.contact = profileRequest.getContact();
+
+        this.mbti = profileRequest.getMbti();
+
+        this.studentId = profileRequest.getStudentId();
+
+        this.personalities = profileRequest.getPersonalities();
+    }
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/entity/ProfileImage.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/ProfileImage.java
@@ -1,0 +1,8 @@
+package com.capstone.wanf.profile.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileImage {
+    BEAR,CAT
+}

--- a/src/main/java/com/capstone/wanf/profile/domain/repo/ProfileRepository.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/repo/ProfileRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.wanf.profile.domain.repo;
+
+import com.capstone.wanf.profile.domain.entity.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+}

--- a/src/main/java/com/capstone/wanf/profile/dto/request/ProfileRequest.java
+++ b/src/main/java/com/capstone/wanf/profile/dto/request/ProfileRequest.java
@@ -1,0 +1,30 @@
+package com.capstone.wanf.profile.dto.request;
+
+import com.capstone.wanf.profile.domain.entity.*;
+import lombok.Data;
+
+
+import java.util.List;
+
+@Data
+public class ProfileRequest {
+    private ProfileImage profileImage;
+
+    private String nickname;
+
+    private Long majorId;
+
+    private Integer studentId;
+
+    private Integer age;
+
+    private Gender gender;
+
+    private MBTI mbti;
+
+    private List<Personality> personalities;
+
+    private List<Goal> goals;
+
+    private String contact;
+}

--- a/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
+++ b/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
@@ -1,0 +1,62 @@
+package com.capstone.wanf.profile.service;
+
+import com.capstone.wanf.major.domain.entity.Major;
+import com.capstone.wanf.major.service.MajorService;
+import com.capstone.wanf.profile.domain.entity.Profile;
+import com.capstone.wanf.profile.domain.repo.ProfileRepository;
+import com.capstone.wanf.profile.dto.request.ProfileRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+    private final ProfileRepository profileRepository;
+
+    private final MajorService majorService;
+
+    @Transactional(readOnly = true)
+    public Profile findById(Long id){
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "프로필이 존재하지 않습니다."));
+
+        return profile;
+    }
+
+    @Transactional
+    public Profile save(ProfileRequest profileRequest) {
+        Major major = majorService.findById(profileRequest.getMajorId());
+
+        Profile saveProfile = Profile.builder()
+                .profileImage(profileRequest.getProfileImage())
+                .nickname(profileRequest.getNickname())
+                .major(major)
+                .studentId(profileRequest.getStudentId())
+                .age(profileRequest.getAge())
+                .gender(profileRequest.getGender())
+                .mbti(profileRequest.getMbti())
+                .personalities(profileRequest.getPersonalities())
+                .goals(profileRequest.getGoals())
+                .contact(profileRequest.getContact())
+                .build();
+
+        Profile profile = profileRepository.save(saveProfile);
+
+        return profile;
+    }
+
+
+    public Profile update(Long id, ProfileRequest profileRequest) {
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "프로필이 존재하지 않습니다."));
+
+        profile.update(profileRequest);
+
+        Profile updateProfile = profileRepository.save(profile);
+
+        return updateProfile;
+    }
+}


### PR DESCRIPTION
- 프로필 작성 수정 조회 기능 추가
- 프로필 엔티티 추가
- 프로필 property 중 이미 정해져 있는 성격, 목표, 성별, mbti, 프로필 이미지는 Enum으로 만들었음
- 빌드를 기존에 buildImage에서 Jib를 사용하였음 (이 빌드 도구가 더 빠르다)
- 전공을 선택하는 것을 major Service를 이용하여 작성하였음, 추후에 major 컨트롤러를 만들어 수업을 선택하듯이 학과도 선택할 수 있게 하면 좋을 것 같다