### PR TITLE
Profile update 메소드 수정

### DIFF
--- a/src/main/java/com/capstone/wanf/profile/domain/entity/Profile.java
+++ b/src/main/java/com/capstone/wanf/profile/domain/entity/Profile.java
@@ -60,7 +60,7 @@ public class Profile extends BaseTimeEntity {
     @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, unique = true)
     private User user;
 
-    public void update(ProfileRequest profileRequest, Major major) {
+    public void updateField(ProfileRequest profileRequest) {
         this.profileImage = profileRequest.getProfileImage();
 
         this.nickname = profileRequest.getNickname();
@@ -78,7 +78,9 @@ public class Profile extends BaseTimeEntity {
         this.studentId = profileRequest.getStudentId();
 
         this.personalities = profileRequest.getPersonalities();
+    }
 
+    public void updateMajor(Major major) {
         this.major = major;
     }
 }

--- a/src/main/java/com/capstone/wanf/profile/dto/request/ProfileRequest.java
+++ b/src/main/java/com/capstone/wanf/profile/dto/request/ProfileRequest.java
@@ -2,12 +2,14 @@ package com.capstone.wanf.profile.dto.request;
 
 import com.capstone.wanf.profile.domain.entity.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
 
 import java.util.List;
 
 @Data
+@Builder
 @Schema(description = "프로필 생성 요청")
 public class ProfileRequest {
     @Schema(description = "프로필 이미지", example = "프로필 이미지")

--- a/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
+++ b/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
@@ -56,9 +56,13 @@ public class ProfileService {
         Profile profile = profileRepository.findById(id)
                 .orElseThrow(() -> new RestApiException(PROFILE_NOT_FOUND));
 
-        Major major = majorService.findById(profileRequest.getMajorId());
+        profile.updateField(profileRequest);
 
-        profile.update(profileRequest, major);
+        if(profileRequest.getMajorId() != null) {
+            Major major = majorService.findById(profileRequest.getMajorId());
+
+            profile.updateMajor(major);
+        }
 
         Profile updateProfile = profileRepository.save(profile);
 


### PR DESCRIPTION
* Major id가 ProfileRequest에 없으면 기존 update 메소드에 들어갈 파라미터가 null이 되어 오류 발생
* update가 실행되면 필드를 update 후 Major id가 ProfileRequest에 있는지 검증 후 updateMajor 메소드를 실행