### PR TITLE
로그인 api error 상태코드 수정

### DIFF
--- a/src/main/java/com/capstone/wanf/auth/jwt/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/capstone/wanf/auth/jwt/service/UserDetailsServiceImpl.java
@@ -1,6 +1,8 @@
 package com.capstone.wanf.auth.jwt.service;
 
 import com.capstone.wanf.auth.jwt.domain.UserDetailsImpl;
+import com.capstone.wanf.error.errorcode.CustomErrorCode;
+import com.capstone.wanf.error.exception.RestApiException;
 import com.capstone.wanf.user.domain.entity.User;
 import com.capstone.wanf.user.domain.repo.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {     // DB에
     @Override
     public UserDetailsImpl loadUserByUsername(String email) throws UsernameNotFoundException {
         User findUser = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("Can't find user with this email. -> " + email));
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.UNAUTHORIZED));
 
         if (findUser != null) {
             UserDetailsImpl userDetails = new UserDetailsImpl(findUser);

--- a/src/main/java/com/capstone/wanf/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/wanf/config/SecurityConfig.java
@@ -28,7 +28,9 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Value("${cors.allowed-origins}")

--- a/src/main/java/com/capstone/wanf/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/wanf/error/handler/GlobalExceptionHandler.java
@@ -3,10 +3,12 @@ package com.capstone.wanf.error.handler;
 
 import com.capstone.wanf.error.dto.response.ErrorResponse;
 import com.capstone.wanf.error.errorcode.CommonErrorCode;
+import com.capstone.wanf.error.errorcode.CustomErrorCode;
 import com.capstone.wanf.error.errorcode.ErrorCode;
 import com.capstone.wanf.error.exception.RestApiException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -22,16 +24,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Object> handleBadCredentialsException() {
+        final ErrorCode errorCode = CustomErrorCode.UNAUTHORIZED;
+
+        return handleExceptionInternal(errorCode);
+    }
+
     // 트랜젝션 예외 처리
     @ExceptionHandler(TransactionSystemException.class)
-    public ResponseEntity<Object> handleTransactionSystemException(final TransactionSystemException ex) {
+    public ResponseEntity<Object> handleTransactionSystemException() {
         final ErrorCode errorCode = CommonErrorCode.TRANSACTION_FAILED;
 
         return handleExceptionInternal(errorCode);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<Object> handleDataIntegrityViolationException(final DataIntegrityViolationException ex) {
+    public ResponseEntity<Object> handleDataIntegrityViolationException() {
         final ErrorCode errorCode = CommonErrorCode.DATA_INTEGRITY_VIOLATION;
 
         return handleExceptionInternal(errorCode);

--- a/src/main/java/com/capstone/wanf/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/wanf/error/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.capstone.wanf.error.errorcode.CommonErrorCode;
 import com.capstone.wanf.error.errorcode.CustomErrorCode;
 import com.capstone.wanf.error.errorcode.ErrorCode;
 import com.capstone.wanf.error.exception.RestApiException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 커스텀 예외 처리
     @ExceptionHandler(RestApiException.class)
@@ -33,14 +35,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     // 트랜젝션 예외 처리
     @ExceptionHandler(TransactionSystemException.class)
-    public ResponseEntity<Object> handleTransactionSystemException() {
+    public ResponseEntity<Object> handleTransactionSystemException(final TransactionSystemException e) {
+        log.warn("handleTransactionSystemException", e);
+
         final ErrorCode errorCode = CommonErrorCode.TRANSACTION_FAILED;
 
         return handleExceptionInternal(errorCode);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<Object> handleDataIntegrityViolationException() {
+    public ResponseEntity<Object> handleDataIntegrityViolationException(final DataIntegrityViolationException e) {
+        log.warn("handleDataIntegrityViolationException", e);
+
         final ErrorCode errorCode = CommonErrorCode.DATA_INTEGRITY_VIOLATION;
 
         return handleExceptionInternal(errorCode);
@@ -49,6 +55,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 예상하지 못한 서버 에러 처리
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleAllException(final Exception ex) {
+        log.warn("handleAllException", ex);
+        
         final ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
 
         return handleExceptionInternal(errorCode, ex.getMessage());


### PR DESCRIPTION
- 로그인 실패 시 Exception의 HttpStatus를 500에서 401로 변경
  - 아이디가 틀렸을 경우
  - 비밀번호가 틀렸을 경우

→ 보안을 위해서 아이디가 틀린 건지 비밀번호가 틀린 건지 정확히 알려주지 않음.