### PR TITLE
User test code 작성

### DIFF
--- a/src/main/java/com/capstone/wanf/auth/jwt/service/AuthService.java
+++ b/src/main/java/com/capstone/wanf/auth/jwt/service/AuthService.java
@@ -36,10 +36,10 @@ public class AuthService {
     // 로그인: 인증 정보 저장 및 Bearer 토큰 발급
     @Transactional
     public TokenResponse login(UserRequest loginDto) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(loginDto.getEmail());
+        UserDetails userDetails = userDetailsService.loadUserByUsername(loginDto.email());
 
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(userDetails.getUsername(), loginDto.getUserPassword(), userDetails.getAuthorities());
+                new UsernamePasswordAuthenticationToken(userDetails.getUsername(), loginDto.userPassword(), userDetails.getAuthorities());
 
         // Authentication 객체를 생성해 SecurityContextHolder에 저장
         Authentication authentication = authenticationManagerBuilder.getObject()

--- a/src/main/java/com/capstone/wanf/user/controller/EmailController.java
+++ b/src/main/java/com/capstone/wanf/user/controller/EmailController.java
@@ -28,12 +28,12 @@ public class EmailController {
                     @ApiResponse(responseCode = "409", ref = "409")
             }
     )
-    public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailRequest emailRequest) {
+    public ResponseEntity<Boolean> sendVerificationCode(@Valid @RequestBody EmailRequest emailRequest) {
         String verificationCode = emailService.generateVerificationCode();      // 인증번호 생성
 
-        emailService.sendVerificationCode(emailRequest, verificationCode);      // 인증번호 전송
+        boolean isSuccess = emailService.sendVerificationCode(emailRequest, verificationCode);      // 인증번호 전송
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(isSuccess);
     }
 
     @PostMapping("/signup/verification")
@@ -46,9 +46,9 @@ public class EmailController {
                     @ApiResponse(responseCode = "404", ref = "404")
             }
     )
-    public ResponseEntity<Void> verify(@RequestBody CodeRequest codeRequest) {
-        emailService.verify(codeRequest);        // 인증번호 검증
+    public ResponseEntity<Boolean> verify(@RequestBody CodeRequest codeRequest) {
+        boolean isSuccess = emailService.verify(codeRequest);        // 인증번호 검증
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(isSuccess);
     }
 }

--- a/src/main/java/com/capstone/wanf/user/controller/UserController.java
+++ b/src/main/java/com/capstone/wanf/user/controller/UserController.java
@@ -130,7 +130,7 @@ public class UserController {
             }
     )
     public ResponseEntity<?> admin(@CurrentUser User user) {
-        userService.getAdminRole(user);
+        userService.grantAdminRole(user);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/capstone/wanf/user/controller/UserController.java
+++ b/src/main/java/com/capstone/wanf/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.capstone.wanf.auth.jwt.service.AuthService;
 import com.capstone.wanf.common.annotation.CurrentUser;
 import com.capstone.wanf.user.domain.entity.User;
 import com.capstone.wanf.user.dto.request.UserRequest;
+import com.capstone.wanf.user.dto.response.UserResponse;
 import com.capstone.wanf.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -32,10 +33,11 @@ public class UserController {
                     @ApiResponse(responseCode = "404", ref = "404")
             }
     )
-    public ResponseEntity<Void> signUp(@Valid @RequestBody UserRequest userRequest) {
-        userService.updateUserPassword(userRequest);        // 회원가입 완료
+    public ResponseEntity<UserResponse> signUp(@Valid @RequestBody UserRequest userRequest) {
+        User newUser = userService.updateUserPassword(userRequest);        // 회원가입 완료
+        userService.createUserDefaultProfile(newUser);      // 기본 프로필 생성
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(newUser.toDTO());
     }
 
     // 로그인 -> 토큰 발급

--- a/src/main/java/com/capstone/wanf/user/domain/entity/User.java
+++ b/src/main/java/com/capstone/wanf/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package com.capstone.wanf.user.domain.entity;
 
 import com.capstone.wanf.common.entity.BaseTimeEntity;
+import com.capstone.wanf.user.dto.response.UserResponse;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -43,5 +44,13 @@ public class User extends BaseTimeEntity {
 
     public void updateRole(Role admin) {
         this.role = admin;
+    }
+
+    public UserResponse toDTO() {
+        return UserResponse.builder()
+                .id(id)
+                .email(email)
+                .role(role)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/wanf/user/domain/repo/UserRepository.java
+++ b/src/main/java/com/capstone/wanf/user/domain/repo/UserRepository.java
@@ -6,7 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmailAndVerificationCode(String email, String verificationCode);
-
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/capstone/wanf/user/dto/request/CodeRequest.java
+++ b/src/main/java/com/capstone/wanf/user/dto/request/CodeRequest.java
@@ -1,14 +1,15 @@
 package com.capstone.wanf.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
+import lombok.Builder;
 
-@Data
+@Builder
 @Schema(description = "인증번호 검증 요청")
-public class CodeRequest {
-    @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
-    private String email;
+public record CodeRequest(
+        @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
+        String email,
 
-    @Schema(description = "인증번호", example = "3AWC94")
-    private String verificationCode;
+        @Schema(description = "인증번호", example = "3AWC94")
+        String verificationCode
+) {
 }

--- a/src/main/java/com/capstone/wanf/user/dto/request/EmailRequest.java
+++ b/src/main/java/com/capstone/wanf/user/dto/request/EmailRequest.java
@@ -1,11 +1,12 @@
 package com.capstone.wanf.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
+import lombok.Builder;
 
-@Data
+@Builder
 @Schema(description = "인증번호 생성 요청")
-public class EmailRequest {
-    @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
-    private String email;
+public record EmailRequest(
+        @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
+        String email
+) {
 }

--- a/src/main/java/com/capstone/wanf/user/dto/request/UserRequest.java
+++ b/src/main/java/com/capstone/wanf/user/dto/request/UserRequest.java
@@ -2,15 +2,14 @@ package com.capstone.wanf.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Data;
 
 @Builder
-@Data
 @Schema(description = "회원가입 요청")
-public class UserRequest {
-    @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
-    private String email;
+public record UserRequest(
+        @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
+        String email,
 
-    @Schema(description = "비밀번호", example = "qwer1234")
-    private String userPassword;
+        @Schema(description = "비밀번호", example = "qwer1234")
+        String userPassword
+) {
 }

--- a/src/main/java/com/capstone/wanf/user/dto/request/UserRequest.java
+++ b/src/main/java/com/capstone/wanf/user/dto/request/UserRequest.java
@@ -1,8 +1,10 @@
 package com.capstone.wanf.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
+@Builder
 @Data
 @Schema(description = "회원가입 요청")
 public class UserRequest {

--- a/src/main/java/com/capstone/wanf/user/dto/response/UserResponse.java
+++ b/src/main/java/com/capstone/wanf/user/dto/response/UserResponse.java
@@ -6,13 +6,14 @@ import lombok.Builder;
 
 @Builder
 @Schema(description = "유저 응답")
-public class UserResponse {
-    @Schema(description = "유저 id", example = "1")
-    private Long id;
+public record UserResponse(
+        @Schema(description = "유저 id", example = "1")
+        Long id,
 
-    @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
-    private String email;
+        @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
+        String email,
 
-    @Schema(description = "권한", example = "일반 사용자")
-    private Role role;
+        @Schema(description = "권한", example = "일반 사용자")
+        Role role
+) {
 }

--- a/src/main/java/com/capstone/wanf/user/dto/response/UserResponse.java
+++ b/src/main/java/com/capstone/wanf/user/dto/response/UserResponse.java
@@ -1,0 +1,18 @@
+package com.capstone.wanf.user.dto.response;
+
+import com.capstone.wanf.user.domain.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "유저 응답")
+public class UserResponse {
+    @Schema(description = "유저 id", example = "1")
+    private Long id;
+
+    @Schema(description = "이메일", example = "wanf@office.skhu.ac.kr")
+    private String email;
+
+    @Schema(description = "권한", example = "일반 사용자")
+    private Role role;
+}

--- a/src/main/java/com/capstone/wanf/user/service/EmailService.java
+++ b/src/main/java/com/capstone/wanf/user/service/EmailService.java
@@ -39,11 +39,11 @@ public class EmailService {
         return verificationCode.toString();
     }
 
-    public void sendVerificationCode(EmailRequest emailRequest, String verificationCode) {
-        String email = emailRequest.getEmail();
+    public boolean sendVerificationCode(EmailRequest emailRequest, String verificationCode) {
+        String email = emailRequest.email();
 
         if (userService.isDuplicateUser(email)) userService.updateVerificationCode(email, verificationCode);
-        
+
         else userService.createUser(email, verificationCode);
 
         SimpleMailMessage message = new SimpleMailMessage();
@@ -55,21 +55,28 @@ public class EmailService {
         message.setText("인증 번호는 [" + verificationCode + "] 입니다.");
 
         mailSender.send(message);
+
+        return true;
     }
 
     @Transactional
-    public void verify(CodeRequest codeRequest) {
-        User user = userService.verifyVerificationCode(codeRequest.getEmail(), codeRequest.getVerificationCode());
+    public boolean verify(CodeRequest codeRequest) {
+        if (userService.isDuplicateUser(codeRequest.email())) {
+            User user = userService.verifyVerificationCode(codeRequest.email(), codeRequest.verificationCode());
 
-        LocalDateTime createdDate = user.getModifiedDate(); // 인증번호 생성 시각
+            LocalDateTime createdDate = user.getModifiedDate(); // 인증번호 생성 시각
 
-        // 인증번호 유효 시간
-        Duration validDuration = Duration.ofMinutes(30);
+            // 인증번호 유효 시간
+            Duration validDuration = Duration.ofMinutes(30);
 
-        LocalDateTime validUntil = createdDate.plus(validDuration);
+            LocalDateTime validUntil = createdDate.plus(validDuration);
 
-        if (LocalDateTime.now().isAfter(validUntil) && user.getUserPassword() == null) {
-            throw new RestApiException(INVALID_VERIFICATION_CODE);
+            if (LocalDateTime.now().isAfter(validUntil)) {
+                throw new RestApiException(INVALID_VERIFICATION_CODE);
+            }
+
+            return true;
         }
+        return false;
     }
 }

--- a/src/main/java/com/capstone/wanf/user/service/EmailService.java
+++ b/src/main/java/com/capstone/wanf/user/service/EmailService.java
@@ -40,27 +40,31 @@ public class EmailService {
     }
 
     public void sendVerificationCode(EmailRequest emailRequest, String verificationCode) {
+        String email = emailRequest.getEmail();
+
+        if (userService.isDuplicateUser(email)) userService.updateVerificationCode(email, verificationCode);
+        
+        else userService.createUser(email, verificationCode);
+
         SimpleMailMessage message = new SimpleMailMessage();
 
-        message.setTo(emailRequest.getEmail());
+        message.setTo(email);
 
         message.setSubject("[From WanF] 이메일 인증 번호입니다.");
 
         message.setText("인증 번호는 [" + verificationCode + "] 입니다.");
-
-        userService.saveOrUpdate(emailRequest.getEmail(), verificationCode);
 
         mailSender.send(message);
     }
 
     @Transactional
     public void verify(CodeRequest codeRequest) {
-        User user = userService.findByEmailAndVerificationCode(codeRequest.getEmail(), codeRequest.getVerificationCode());
+        User user = userService.verifyVerificationCode(codeRequest.getEmail(), codeRequest.getVerificationCode());
 
         LocalDateTime createdDate = user.getModifiedDate(); // 인증번호 생성 시각
 
         // 인증번호 유효 시간
-        Duration validDuration = Duration.ofMinutes(10);
+        Duration validDuration = Duration.ofMinutes(30);
 
         LocalDateTime validUntil = createdDate.plus(validDuration);
 

--- a/src/main/java/com/capstone/wanf/user/service/UserService.java
+++ b/src/main/java/com/capstone/wanf/user/service/UserService.java
@@ -63,7 +63,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserPassword(UserRequest userRequest) {
+    public User updateUserPassword(UserRequest userRequest) {
         User user = findByEmail(userRequest.getEmail());
 
         // 비밀번호 저장
@@ -74,6 +74,8 @@ public class UserService {
 
         // 프로필 생성
         profileService.defaultSave(user);
+        
+        return user;
     }
 
     public User verifyVerificationCode(String email, String verificationCode) {

--- a/src/main/java/com/capstone/wanf/user/service/UserService.java
+++ b/src/main/java/com/capstone/wanf/user/service/UserService.java
@@ -65,10 +65,10 @@ public class UserService {
 
     @Transactional
     public User updateUserPassword(UserRequest userRequest) {
-        User user = findByEmail(userRequest.getEmail());
+        User user = findByEmail(userRequest.email());
 
         // 비밀번호 저장
-        String encodedPassword = encoder.encode(userRequest.getUserPassword());
+        String encodedPassword = encoder.encode(userRequest.userPassword());
         user.updateUserPassword(encodedPassword);
 
         userRepository.save(user);

--- a/src/main/java/com/capstone/wanf/user/service/UserService.java
+++ b/src/main/java/com/capstone/wanf/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.capstone.wanf.user.service;
 
 import com.capstone.wanf.error.exception.RestApiException;
+import com.capstone.wanf.profile.domain.entity.Profile;
 import com.capstone.wanf.profile.service.ProfileService;
 import com.capstone.wanf.user.domain.entity.Role;
 import com.capstone.wanf.user.domain.entity.User;
@@ -72,10 +73,12 @@ public class UserService {
 
         userRepository.save(user);
 
-        // 프로필 생성
-        profileService.defaultSave(user);
-        
         return user;
+    }
+
+    // 프로필 생성
+    public Profile createUserDefaultProfile(User user) {
+        return profileService.defaultSave(user);
     }
 
     public User verifyVerificationCode(String email, String verificationCode) {

--- a/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
+++ b/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
@@ -4,6 +4,7 @@ import com.capstone.wanf.comment.domain.entity.Comment;
 import com.capstone.wanf.comment.dto.request.CommentRequest;
 import com.capstone.wanf.course.domain.entity.Course;
 import com.capstone.wanf.course.domain.entity.Major;
+import com.capstone.wanf.course.dto.request.CourseRequest;
 import com.capstone.wanf.post.domain.entity.Category;
 import com.capstone.wanf.post.domain.entity.Post;
 import com.capstone.wanf.post.dto.request.PostRequest;
@@ -11,7 +12,7 @@ import com.capstone.wanf.profile.domain.entity.*;
 import com.capstone.wanf.profile.dto.request.ProfileRequest;
 import com.capstone.wanf.user.domain.entity.Role;
 import com.capstone.wanf.user.domain.entity.User;
-import com.capstone.wanf.course.dto.request.CourseRequest;
+import com.capstone.wanf.user.dto.request.UserRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -194,5 +195,10 @@ public class DomainFixture {
             .category(Category.friend)
             .profile(프로필1)
             .comments(new ArrayList<>(Arrays.asList(댓글1)))
+            .build();
+
+    public static final UserRequest 회원가입_요청1 = UserRequest.builder()
+            .email("test@email.com")
+            .userPassword("0000")
             .build();
 }

--- a/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
+++ b/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
@@ -54,7 +54,16 @@ public class DomainFixture {
             .email("wanf@gmail.com")
             .userPassword("1234@@qwer")
             .verificationCode("5678")
+            .role(Role.USER)
             .build();
+
+    public static final User 유저3 = User.builder()
+            .email("wanf@gmail.com")
+            .userPassword(null)
+            .verificationCode("5678")
+            .role(Role.USER)
+            .build();
+    
     public static final Profile 프로필1 = Profile.builder()
             .nickname("닉네임1")
             .studentId(12345678)

--- a/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
+++ b/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
@@ -12,6 +12,8 @@ import com.capstone.wanf.profile.domain.entity.*;
 import com.capstone.wanf.profile.dto.request.ProfileRequest;
 import com.capstone.wanf.user.domain.entity.Role;
 import com.capstone.wanf.user.domain.entity.User;
+import com.capstone.wanf.user.dto.request.CodeRequest;
+import com.capstone.wanf.user.dto.request.EmailRequest;
 import com.capstone.wanf.user.dto.request.UserRequest;
 
 import java.util.ArrayList;
@@ -63,7 +65,7 @@ public class DomainFixture {
             .verificationCode("5678")
             .role(Role.USER)
             .build();
-    
+
     public static final Profile 프로필1 = Profile.builder()
             .nickname("닉네임1")
             .studentId(12345678)
@@ -209,5 +211,14 @@ public class DomainFixture {
     public static final UserRequest 회원가입_요청1 = UserRequest.builder()
             .email("test@email.com")
             .userPassword("0000")
+            .build();
+
+    public static final CodeRequest 인증번호_요청1 = CodeRequest.builder()
+            .email("test@email.com")
+            .verificationCode("1234")
+            .build();
+
+    public static final EmailRequest 이메일_요청1 = EmailRequest.builder()
+            .email("mongbu54@gmail.com")
             .build();
 }

--- a/src/test/java/com/capstone/wanf/user/domain/repo/UserRepositoryTest.java
+++ b/src/test/java/com/capstone/wanf/user/domain/repo/UserRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.capstone.wanf.user.domain.repo;
+
+import com.capstone.wanf.fixture.DomainFixture;
+import com.capstone.wanf.user.domain.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest        // JPA관련 테스트 설정만 로드
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)        // application.yml에 정의된 DB 사용
+public class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    private User 유저1;
+
+    @BeforeEach
+    void setUp() {
+        유저1 = userRepository.save(DomainFixture.유저2);
+    }
+
+    @Test
+    @DisplayName("이메일로 유저를 조회한다")
+    void findByEmailSuccess() {
+        //when
+        User user = userRepository.findByEmail(유저1.getEmail()).orElseThrow();
+        //then
+        Assertions.assertThat(user).isEqualTo(유저1);
+    }
+}

--- a/src/test/java/com/capstone/wanf/user/service/EmailServiceTest.java
+++ b/src/test/java/com/capstone/wanf/user/service/EmailServiceTest.java
@@ -40,9 +40,6 @@ public class EmailServiceTest {
         @Test
         @DisplayName("기존 유저는 false 반환")
         void verifyExistingUserReturnsFalse() {
-            // given
-            given(userService.isDuplicateUser(any(String.class))).willReturn(false);
-
             // when
             boolean isSuccess = emailService.verify(인증번호_요청1);
 
@@ -56,12 +53,14 @@ public class EmailServiceTest {
             // given
             // Jpa Auditing을 사용한 User 객체는 생성 시간, 수정 시간을 Builder로 직접 설정 불가능 -> Mock 객체를 사용해 기댓값을 직접 작성해 테스트
             User unexpiredUser = Mockito.mock(User.class);
+
             LocalDateTime modifiedDate = LocalDateTime.now().minusMinutes(29);
-            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
+
+            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
 
             given(userService.verifyVerificationCode(any(String.class), any(String.class))).willReturn(unexpiredUser);
 
-            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
+            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
 
             // when
             boolean isSuccess = emailService.verify(인증번호_요청1);
@@ -75,12 +74,14 @@ public class EmailServiceTest {
         void expiredVerificationCodeTest() {
             // given
             User unexpiredUser = Mockito.mock(User.class);
+
             LocalDateTime modifiedDate = LocalDateTime.now().minusMinutes(31);
-            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
+
+            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
 
             given(userService.verifyVerificationCode(인증번호_요청1.email(), 인증번호_요청1.verificationCode())).willReturn(unexpiredUser);
 
-            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
+            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
 
             // when & then
             assertThatThrownBy(() -> emailService.verify(인증번호_요청1))

--- a/src/test/java/com/capstone/wanf/user/service/EmailServiceTest.java
+++ b/src/test/java/com/capstone/wanf/user/service/EmailServiceTest.java
@@ -1,0 +1,107 @@
+package com.capstone.wanf.user.service;
+
+import com.capstone.wanf.error.exception.RestApiException;
+import com.capstone.wanf.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDateTime;
+
+import static com.capstone.wanf.fixture.DomainFixture.이메일_요청1;
+import static com.capstone.wanf.fixture.DomainFixture.인증번호_요청1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailServiceTest {
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Nested
+    @DisplayName("인증번호 만료 여부 검사")
+    class verifyTest {
+        @Test
+        @DisplayName("기존 유저는 false 반환")
+        void verifyExistingUserReturnsFalse() {
+            // given
+            given(userService.isDuplicateUser(any(String.class))).willReturn(false);
+
+            // when
+            boolean isSuccess = emailService.verify(인증번호_요청1);
+
+            // then
+            assertThat(isSuccess).isFalse();
+        }
+
+        @Test
+        @DisplayName("생성 후 30분 이하")
+        void unexpiredVerificationCodeTest() {
+            // given
+            // Jpa Auditing을 사용한 User 객체는 생성 시간, 수정 시간을 Builder로 직접 설정 불가능 -> Mock 객체를 사용해 기댓값을 직접 작성해 테스트
+            User unexpiredUser = Mockito.mock(User.class);
+            LocalDateTime modifiedDate = LocalDateTime.now().minusMinutes(29);
+            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
+
+            given(userService.verifyVerificationCode(any(String.class), any(String.class))).willReturn(unexpiredUser);
+
+            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
+
+            // when
+            boolean isSuccess = emailService.verify(인증번호_요청1);
+
+            // then
+            assertThat(isSuccess).isTrue();
+        }
+
+        @Test
+        @DisplayName("생성 후 30분을 초과해 예외가 발생")
+        void expiredVerificationCodeTest() {
+            // given
+            User unexpiredUser = Mockito.mock(User.class);
+            LocalDateTime modifiedDate = LocalDateTime.now().minusMinutes(31);
+            given(unexpiredUser.getModifiedDate()).willReturn(modifiedDate);
+
+            given(userService.verifyVerificationCode(인증번호_요청1.email(), 인증번호_요청1.verificationCode())).willReturn(unexpiredUser);
+
+            given(userService.isDuplicateUser(any(String.class))).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> emailService.verify(인증번호_요청1))
+                    .isInstanceOf(RestApiException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("재전송을 요청하면 인증번호를 갱신한다")
+    void existingUserUpdateVerificationCode() {
+        // given
+        given(userService.isDuplicateUser(any(String.class))).willReturn(true);
+
+        // when
+        boolean isSuccess = emailService.sendVerificationCode(이메일_요청1, "1234");
+
+        // then
+        verify(userService).updateVerificationCode(이메일_요청1.email(), "1234");
+
+        verify(mailSender).send(any(SimpleMailMessage.class));
+
+        assertThat(isSuccess).isTrue();
+    }
+}

--- a/src/test/java/com/capstone/wanf/user/service/UserServiceTest.java
+++ b/src/test/java/com/capstone/wanf/user/service/UserServiceTest.java
@@ -1,7 +1,6 @@
 package com.capstone.wanf.user.service;
 
 import com.capstone.wanf.error.exception.RestApiException;
-import com.capstone.wanf.profile.service.ProfileService;
 import com.capstone.wanf.user.domain.entity.Role;
 import com.capstone.wanf.user.domain.entity.User;
 import com.capstone.wanf.user.domain.repo.UserRepository;
@@ -33,9 +32,6 @@ public class UserServiceTest {
 
     @Mock
     private BCryptPasswordEncoder encoder;
-
-    @Mock
-    private ProfileService profileService;
 
     @Test
     @DisplayName("이메일로 유저를 조회한다")

--- a/src/test/java/com/capstone/wanf/user/service/UserServiceTest.java
+++ b/src/test/java/com/capstone/wanf/user/service/UserServiceTest.java
@@ -1,0 +1,156 @@
+package com.capstone.wanf.user.service;
+
+import com.capstone.wanf.error.exception.RestApiException;
+import com.capstone.wanf.profile.service.ProfileService;
+import com.capstone.wanf.user.domain.entity.Role;
+import com.capstone.wanf.user.domain.entity.User;
+import com.capstone.wanf.user.domain.repo.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static com.capstone.wanf.fixture.DomainFixture.유저2;
+import static com.capstone.wanf.fixture.DomainFixture.회원가입_요청1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private BCryptPasswordEncoder encoder;
+
+    @Mock
+    private ProfileService profileService;
+
+    @Test
+    @DisplayName("이메일로 유저를 조회한다")
+    void findByEmailSuccess() {
+        // given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        //when
+        User user = userService.findByEmail(유저2.getEmail());
+
+        //then
+        assertThat(user).isEqualTo(유저2);
+    }
+
+    @Test
+    @DisplayName("이메일 조회 결과가 null이면 예외가 발생한다")
+    void findByEmailThrowException() {
+        // given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.findByEmail("test@email.com"))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("인증번호가 유저 인증번호와 일치한다")
+    void verifyVerificationCodeSuccess() {
+        //given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        // when
+        User user = userService.verifyVerificationCode(유저2.getEmail(), 유저2.getVerificationCode());
+
+        //then
+        assertThat(user).isEqualTo(유저2);
+    }
+
+    @Test
+    @DisplayName("인증번호 불일치 시 예외가 발생한다")
+    void verifyVerificationCodeThrowException() {
+        //given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        // when & then
+        assertThatThrownBy(() -> userService.verifyVerificationCode(유저2.getEmail(), "1234"))
+                .isInstanceOf(RestApiException.class);
+    }
+
+
+    @Test
+    @DisplayName("새로운 이메일인 경우 유저를 저장한다")
+    void saveNewUser() {
+        // when
+        userService.createUser("test@email.com", "1234");
+
+        // then
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("인증번호 재발급 시 유저의 인증번호를 갱신한다")
+    void updateVerificationCode() {
+        // given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        // when
+        userService.updateVerificationCode(유저2.getEmail(), "1234");
+
+        // then
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("기존 유저의 이메일인 경우 예외가 발생한다")
+    void existingUserThrowException() {
+        // given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        // when & then
+        assertThatThrownBy(() -> userService.isDuplicateUser(유저2.getEmail()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("사용자의 비밀번호가 업데이트되고 프로필이 생성된다")
+    void updateUserPasswordSuccess() {
+        // given
+        given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(유저2));
+
+        given(encoder.encode(any(String.class))).willReturn(유저2.getUserPassword());
+
+        // when
+        userService.updateUserPassword(회원가입_요청1);
+
+        // then
+        verify(userRepository).save(any(User.class));
+
+        verify(profileService).defaultSave(any(User.class));
+    }
+
+    @Test
+    @DisplayName("사용자에게 관리자 권한을 부여한다")
+    void grantAdminRoleSuccess() {
+        // given
+        User user = 유저2;
+
+        // when
+        userService.grantAdminRole(유저2);
+
+        // then
+        verify(userRepository).save(유저2);
+
+        assertThat(user.getRole()).isEqualTo(Role.ADMIN);
+    }
+}
+
+


### PR DESCRIPTION
- UserRepository, UserService 테스트 코드 작성
- 권한을 부여하는 메소드명은 get보다 grant가 적합할 것 같아 변경
- 메일을 전송하기 전에 가입 여부를 확인하도록 메소드 분리
- 입력받은 인증번호와 전송된 인증번호의 일치 여부를 판단할 때, and 조건보다 유저 정보와 비교하는 것이 적절할 것 같아 변경