### PR TITLE
기본 프로필 이미지 삭제

### DIFF
--- a/src/main/java/com/capstone/wanf/profile/dto/request/ProfileImageRequest.java
+++ b/src/main/java/com/capstone/wanf/profile/dto/request/ProfileImageRequest.java
@@ -1,11 +1,13 @@
 package com.capstone.wanf.profile.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "이미지를 포함한 프로필 요청")
 public record ProfileImageRequest(
+        @NotNull(message = "프로필 이미지는 null이 될 수 없습니다.")
         @Schema(description = "이미지 id", example = "1")
         Long imageId,
         @Schema(implementation = ProfileRequest.class, description = "프로필 나머지 데이터")

--- a/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
+++ b/src/main/java/com/capstone/wanf/profile/service/ProfileService.java
@@ -67,8 +67,7 @@ public class ProfileService {
 
         Major major = majorService.findById(profileRequest.majorId());
 
-        Image image = profileImageRequest.imageId() != null
-                ? s3Service.findById(profileImageRequest.imageId()) : s3Service.findById(1L);
+        Image image = s3Service.findById(profileImageRequest.imageId());
 
         Profile profile = Profile.builder()
                 .user(user)
@@ -95,15 +94,13 @@ public class ProfileService {
         Profile profile = profileRepository.findByUser(user)
                 .orElseThrow(() -> new RestApiException(PROFILE_NOT_FOUND));
 
-        if (profileImageRequest.imageId() != null) {
+        Image userImage = profile.getImage();
+
+        // 프로필 이미지가 변경되었을 경우
+        if (userImage.getId() != profileImageRequest.imageId()) {
             Image changeImage = s3Service.findById(profileImageRequest.imageId());
 
-            Image userImage = profile.getImage();
-
-            // 기본 이미지가 아니고, 기존 이미지와 바꾸려는 이미지가 다르면 기존 이미지 삭제
-            if (userImage.getId() != 1L && userImage.getId() != changeImage.getId()) {
-                s3Service.delete(userImage);
-            }
+            s3Service.delete(userImage);
 
             profile.updateImage(changeImage);
         }

--- a/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
+++ b/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
@@ -166,6 +166,7 @@ public class DomainFixture {
             .build();
 
     public static final ProfileImageRequest 프로필_이미지_수정1 = ProfileImageRequest.builder()
+            .imageId(1L)
             .profileRequest(프로필_수정1)
             .build();
 
@@ -326,5 +327,5 @@ public class DomainFixture {
             .content("쪽지_응답2")
             .build();
 
-    public static final List<MessageResponse> 쪽지_목록1 =  List.of(쪽지_응답1, 쪽지_응답2);
+    public static final List<MessageResponse> 쪽지_목록1 = List.of(쪽지_응답1, 쪽지_응답2);
 }

--- a/src/test/java/com/capstone/wanf/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/capstone/wanf/profile/service/ProfileServiceTest.java
@@ -107,6 +107,8 @@ class ProfileServiceTest {
             given(profileRepository.findByUser(any(User.class))).willReturn(Optional.of(프로필3));
 
             given(majorService.findById(anyLong())).willReturn(전공1);
+
+            given(s3Service.findById(anyLong())).willReturn(이미지1);
             //when
             Profile profile = profileService.update(유저1, 프로필_이미지_수정1);
             //then
@@ -117,8 +119,6 @@ class ProfileServiceTest {
         void 프로필의_이미지만을_수정한다() {
             //given
             given(profileRepository.findByUser(any(User.class))).willReturn(Optional.of(프로필3));
-
-            given(s3Service.findById(anyLong())).willReturn(이미지1);
             //when
             Profile profile = profileService.update(유저1, 프로필_이미지_수정3);
             //then
@@ -149,8 +149,6 @@ class ProfileServiceTest {
             given(profileRepository.findByUser(any(User.class))).willReturn(Optional.of(프로필3));
 
             given(majorService.findById(anyLong())).willReturn(전공1);
-
-            given(s3Service.findById(anyLong())).willReturn(이미지1);
             //when
             Profile profile = profileService.update(유저1, 프로필_이미지_수정3);
             //then
@@ -203,15 +201,5 @@ class ProfileServiceTest {
         Profile profile = profileService.save(프로필_이미지_수정3, 유저1);
         //then
         assertThat(profile).isEqualTo(프로필1);
-    }
-
-    @Test
-    void 프로필_요청의_imageId가_null이면_기본_이미지를_저장한다() {
-        //given
-        given(profileRepository.save(any(Profile.class))).willReturn(프로필1);
-        //when
-        Profile profile = profileService.save(프로필_이미지_수정1, 유저2);
-        //then
-        assertThat(profile.getImage()).isEqualTo(이미지1);
     }
 }


### PR DESCRIPTION
Issue No: #102 

### 문제
- 전공 수정과 예외처리 메서드를 제외한 테스트 메서드에서 프로필 Image가 null이어서 실패하는 문제가 발생

### 원인
- 전공 수정 테스트 메서드에서 프로필3의 이미지에 대한 반환 값을 정의 X. 이로 인해 해당 프로필의 이미지가 null로 설정되어 이후의 테스트가 모두 실패 → 같은 테스트 클래스 내에서 Mock 객체는 공유된다는 점을 기억해두기 