### PR TITLE
모임, 모임 게시글 test code 추가 및 리펙토링 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'com.google.firebase:firebase-admin:8.1.0'
+    implementation  'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -56,7 +57,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'com.h2database:h2'
-    implementation  'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {
@@ -64,7 +64,6 @@ tasks.named('test') {
 }
 
 jacoco {
-    // jacoco 버전
     toolVersion = '0.8.7'
 }
 
@@ -118,6 +117,7 @@ jacocoTestReport {
                               "com/capstone/wanf/config/**",
                               "com/capstone/wanf/common/**",
                               "com/capstone/wanf/**/dto/**",
+                              "com/capstone/wanf/auth/**",
                               "com/capstone/wanf/user/controller/EmailController.class",
                               "com/capstone/wanf/WanFApplication.class"] + Qdomains)
         }))
@@ -127,25 +127,21 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     violationRules {
         rule {
-            // 각 클래스
             element = 'CLASS'
 
 
-            // 분기문 커버리지
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
                 minimum = 0
             }
 
-            // 라인 커버리지
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
                 minimum = 0.0
             }
 
-            // 코드에서 사용하는 메소드 중, 테스트가 실행된 메소드의 비율
             limit {
                 counter = 'METHOD'
                 value = 'COVEREDRATIO'
@@ -158,14 +154,13 @@ jacocoTestCoverageVerification {
                     '**/*Response*',
                     '**/*config*',
                     '**/*ErrorCode*',
-                    "*Q*", // querydsl
+                    "*Q*",
             ]
         }
 
         rule {
             element = 'METHOD'
 
-            // 최대 method 라인 수
             limit {
                 counter = 'LINE'
                 value = 'TOTALCOUNT'

--- a/src/main/java/com/capstone/wanf/club/domain/entity/Club.java
+++ b/src/main/java/com/capstone/wanf/club/domain/entity/Club.java
@@ -49,8 +49,10 @@ public class Club extends BaseTimeEntity {
         this.recruitmentStatus = true;
     }
 
-    public void removePost(Long postId) {
+    public List<ClubPost> removePost(Long postId) {
         this.posts.removeIf(post -> post.getId().equals(postId));
+
+        return this.posts;
     }
 
     public ClubResponse toResponse() {

--- a/src/main/java/com/capstone/wanf/club/dto/request/ClubPostRequest.java
+++ b/src/main/java/com/capstone/wanf/club/dto/request/ClubPostRequest.java
@@ -2,7 +2,9 @@ package com.capstone.wanf.club.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "모임 게시글 생성 요청")
 public record ClubPostRequest(
         @NotBlank(message = "공백이나 null이 될 수 없습니다.")

--- a/src/main/java/com/capstone/wanf/club/dto/request/ClubRequest.java
+++ b/src/main/java/com/capstone/wanf/club/dto/request/ClubRequest.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 @Schema(description = "모임 생성 요청")
 public record ClubRequest(
         @NotBlank

--- a/src/main/java/com/capstone/wanf/club/service/ClubAuthService.java
+++ b/src/main/java/com/capstone/wanf/club/service/ClubAuthService.java
@@ -4,6 +4,7 @@ import com.capstone.wanf.club.domain.entity.Authority;
 import com.capstone.wanf.club.domain.entity.Club;
 import com.capstone.wanf.club.domain.entity.ClubAuth;
 import com.capstone.wanf.club.domain.repo.ClubAuthRepository;
+import com.capstone.wanf.club.dto.response.ClubResponse;
 import com.capstone.wanf.error.exception.RestApiException;
 import com.capstone.wanf.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +12,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.capstone.wanf.error.errorcode.CommonErrorCode.CLUB_FORBIDDEN;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class ClubAuthService {
     private final ClubAuthRepository clubAuthRepository;
 
@@ -31,10 +33,12 @@ public class ClubAuthService {
     }
 
     @Transactional(readOnly = true)
-    public List<ClubAuth> findByUserId(Long userId) {
-        List<ClubAuth> clubAuthList = clubAuthRepository.findByUserId(userId);
+    public List<ClubResponse> findByUserId(Long userId) {
+        List<ClubResponse> clubResponses = clubAuthRepository.findByUserId(userId).stream()
+                .map(clubAuth -> clubAuth.getClub().toResponse())
+                .collect(Collectors.toList());
 
-        return clubAuthList;
+        return clubResponses;
     }
 
     @Transactional(readOnly = true)
@@ -46,6 +50,7 @@ public class ClubAuthService {
         return userAuth.getAuthority();
     }
 
+    @Transactional(readOnly = true)
     public Authority getAuthority(Long userId, Long clubId) {
         Authority userAuth = findByUserIdAndClubId(userId, clubId);
 

--- a/src/main/java/com/capstone/wanf/club/service/ClubService.java
+++ b/src/main/java/com/capstone/wanf/club/service/ClubService.java
@@ -6,6 +6,7 @@ import com.capstone.wanf.club.domain.repo.ClubRepository;
 import com.capstone.wanf.club.dto.request.ClubPwdRequest;
 import com.capstone.wanf.club.dto.request.ClubRequest;
 import com.capstone.wanf.error.exception.RestApiException;
+import com.capstone.wanf.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +17,12 @@ import static com.capstone.wanf.error.errorcode.CommonErrorCode.*;
 import static com.capstone.wanf.error.errorcode.CustomErrorCode.CLUB_NOT_FOUND;
 import static com.capstone.wanf.error.errorcode.CustomErrorCode.CLUB_UNAUTHORIZED;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class ClubService {
     private final ClubRepository clubRepository;
+
+    private final ClubAuthService clubAuthService;
 
     @Transactional(readOnly = true)
     public List<Club> findAll() {
@@ -36,7 +39,18 @@ public class ClubService {
     }
 
     @Transactional
-    public Club save(ClubRequest clubRequest) {
+    public void joinClub(User user, ClubPwdRequest clubPwdRequest) {
+        Club club = findById(clubPwdRequest.clubId());
+
+        Authority userAuth = clubAuthService.findByUserIdAndClubId(user.getId(), club.getId());
+
+        if (checkClubAccess(club, clubPwdRequest, userAuth)) {
+            clubAuthService.grantAuthorityToClub(user, club, Authority.CLUB_MEMBER);
+        }
+    }
+
+    @Transactional
+    public Club save(ClubRequest clubRequest, User user) {
         Club club = Club.builder()
                 .name(clubRequest.name())
                 .maxParticipants(clubRequest.maxParticipants())
@@ -47,11 +61,35 @@ public class ClubService {
 
         if (clubRequest.maxParticipants() == 1) club.updateRecruitmentStatus();
 
-        return clubRepository.save(club);
+        Club saveClub = clubRepository.save(club);
+
+        clubAuthService.grantAuthorityToClub(user, club, Authority.CLUB_LEADER);
+
+        return saveClub;
     }
 
-    @Transactional
-    public Boolean checkClubAccess(Club club, ClubPwdRequest clubPwdRequest, Authority userAuth) {
+    @Transactional(readOnly = true)
+    public Authority checkAuthority(Long clubId, User user) {
+        Club club = findById(clubId);
+
+        Authority userAuth = clubAuthService.getAuthority(user.getId(), club.getId());
+
+        return userAuth;
+    }
+
+    @Transactional(readOnly = true)
+    public ClubPwdRequest getPassword(Long clubId) {
+        Club club = findById(clubId);
+
+        ClubPwdRequest clubPwdRequest = ClubPwdRequest.builder()
+                .clubId(clubId)
+                .password(club.getPassword())
+                .build();
+
+        return clubPwdRequest;
+    }
+
+    private Boolean checkClubAccess(Club club, ClubPwdRequest clubPwdRequest, Authority userAuth) {
         checkRecruitmentStatus(club);
 
         checkUserAuthority(userAuth);
@@ -81,7 +119,9 @@ public class ClubService {
         }
     }
     
-    public void updateRecruitmentStatusIfFull(Club club) {
+    private void updateRecruitmentStatusIfFull(Club club) {
+        club.updateCurrentParticipants();
+
         if (club.getMaxParticipants() == club.getCurrentParticipants()) {
             club.updateRecruitmentStatus();
         }

--- a/src/test/java/com/capstone/wanf/ControllerTest.java
+++ b/src/test/java/com/capstone/wanf/ControllerTest.java
@@ -59,6 +59,10 @@ public class ControllerTest {
 
     private static final String REFRESH_TOKEN = "refreshToken";
 
+    private static final String CLUB_PATH = "/clubs";
+
+    private static final String CLUB_POST_PATH = "/clubposts";
+
     @Autowired
     protected JwtTokenProvider tokenProvider;
 
@@ -225,6 +229,51 @@ public class ControllerTest {
                 Map.of("Authorization", accessToken));
     }
 
+    protected ExtractableResponse<Response> 모임_생성(String accessToken, Object body) {
+        return post(String.format("%s%s", BASE_PATH, CLUB_PATH),
+                Map.of("Authorization", accessToken), body);
+    }
+
+    protected ExtractableResponse<Response> 모임_모두_조회(String accessToken) {
+        return get(String.format("%s%s", BASE_PATH, CLUB_PATH),
+                Map.of("Authorization", accessToken));
+    }
+
+    protected ExtractableResponse<Response> 모임_가입(String accessToken, Object body) {
+        return post(String.format("%s%s%s", BASE_PATH, CLUB_PATH, "/join"),
+                Map.of("Authorization", accessToken), body);
+    }
+
+    protected ExtractableResponse<Response> 모임_권한_확인(String accessToken, Long id) {
+        return get(String.format("%s%s/%d", BASE_PATH, CLUB_PATH, id),
+                Map.of("Authorization", accessToken));
+    }
+
+    protected ExtractableResponse<Response> 모임_비밀번호_확인(String accessToken, Long id) {
+        return get(String.format("%s%s/%d%s", BASE_PATH, CLUB_PATH, id, "/password"),
+                Map.of("Authorization", accessToken));
+    }
+
+    protected ExtractableResponse<Response> 모임_게시글_생성(String accessToken, Object body, Long id) {
+        return post(String.format("%s%s/%d%s", BASE_PATH, CLUB_PATH, id, CLUB_POST_PATH),
+                Map.of("Authorization", accessToken), body);
+    }
+
+    protected ExtractableResponse<Response> 모임_게시글_조회(String accessToken, Long clubId, Long clubPostId) {
+        return get(String.format("%s%s/%d%s/%d", BASE_PATH, CLUB_PATH, clubId, CLUB_POST_PATH, clubPostId),
+                Map.of("Authorization", accessToken));
+    }
+
+    protected ExtractableResponse<Response> 모임_게시글_모두_조회(String accessToken, Long clubId) {
+        return get(String.format("%s%s/%d%s", BASE_PATH, CLUB_PATH, clubId, CLUB_POST_PATH),
+                Map.of("Authorization", accessToken));
+    }
+
+    protected ExtractableResponse<Response> 모임_게시글_삭제(String accessToken, Long clubId, Long clubPostId) {
+        return delete(String.format("%s%s/%d%s/%d", BASE_PATH, CLUB_PATH, clubId, CLUB_POST_PATH, clubPostId),
+                Map.of("Authorization", accessToken));
+    }
+
     protected ExtractableResponse<Response> 인증번호_요청() {
         JSONObject jsonObject = new JSONObject();
 
@@ -269,13 +318,13 @@ public class ControllerTest {
 
         jsonObject.put("userPassword", "test");
 
-        post(String.format("%s%s%s/%s", BASE_PATH, AUTH_PATH, SIGN_UP_PATH, "user"), jsonObject);
+        ExtractableResponse<Response> 회원가입 = post(String.format("%s%s%s/%s", BASE_PATH, AUTH_PATH, SIGN_UP_PATH, "user"), jsonObject);
 
-        ExtractableResponse<Response> userResponse = post(String.format("%s%s%s", BASE_PATH, AUTH_PATH, LOGIN_PATH), Map.of("FCM-TOKEN", FCM_TOKEN), jsonObject);
-
-        String accessToken = userResponse.header("Authorization");
+        String accessToken = 회원가입.header("Authorization");
 
         post(String.format("%s%s", BASE_PATH, PROFILE_PATH), Map.of("Authorization", accessToken), 프로필_이미지_저장);
+
+        post(String.format("%s%s%s", BASE_PATH, AUTH_PATH, LOGIN_PATH), Map.of("FCM-TOKEN", FCM_TOKEN), jsonObject);
 
         get(String.format("%s%s%s", BASE_PATH, AUTH_PATH, ADMIN_PATH), Map.of("Authorization", accessToken));
 

--- a/src/test/java/com/capstone/wanf/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/capstone/wanf/club/controller/ClubControllerTest.java
@@ -1,0 +1,82 @@
+package com.capstone.wanf.club.controller;
+
+import com.capstone.wanf.ControllerTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static com.capstone.wanf.fixture.DomainFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClubControllerTest extends ControllerTest {
+    @Test
+    void 모임을_생성한다() {
+        //given
+        String accessToken = getAccessToken();
+        //when
+        ExtractableResponse<Response> 모임_생성 = 모임_생성(accessToken, 모임_요청1);
+        //then
+        assertAll(
+                () -> assertThat(모임_생성.statusCode()).isEqualTo(200),
+                () -> assertThat(모임_생성.body().jsonPath().getLong("id")).isNotNull()
+        );
+    }
+
+    @Test
+    void 모임을_모두_조회한다(){
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청1);
+        //when
+        ExtractableResponse<Response> 모임_모두_조회 = 모임_모두_조회(accessToken);
+        //then
+        assertAll(
+                () -> assertThat(모임_모두_조회.statusCode()).isEqualTo(200),
+                () -> assertThat(모임_모두_조회.body().jsonPath().getList("id").size()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 모임에_가입한다(){
+        //given
+        String accessToken = getAccessToken();
+
+        String adminAccessToken = getAdminAccessToken();
+
+        모임_생성(accessToken, 모임_요청2);
+        //when
+        ExtractableResponse<Response> 모임_가입 = 모임_가입(adminAccessToken, 모임_비밀번호_요청1);
+        //then
+        assertThat(모임_가입.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void 모임_권한을_확인한다(){
+        //given
+        String accessToken = getAccessToken();
+
+        String adminAccessToken = getAdminAccessToken();
+
+        모임_생성(accessToken, 모임_요청2);
+
+        모임_가입(adminAccessToken, 모임_비밀번호_요청1);
+        //when
+        ExtractableResponse<Response> 모임_권한_확인 = 모임_권한_확인(adminAccessToken, 1L);
+        //then
+        assertThat(모임_권한_확인.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void 모임_비밀번호를_조회한다(){
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청2);
+        //when
+        ExtractableResponse<Response> 모임_비밀번호_조회 = 모임_비밀번호_확인(accessToken, 1L);
+        //then
+        assertThat(모임_비밀번호_조회.statusCode()).isEqualTo(200);
+    }
+}

--- a/src/test/java/com/capstone/wanf/club/controller/ClubPostControllerTest.java
+++ b/src/test/java/com/capstone/wanf/club/controller/ClubPostControllerTest.java
@@ -1,0 +1,77 @@
+package com.capstone.wanf.club.controller;
+
+import com.capstone.wanf.ControllerTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static com.capstone.wanf.fixture.DomainFixture.모임_게시글_요청1;
+import static com.capstone.wanf.fixture.DomainFixture.모임_요청1;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClubPostControllerTest extends ControllerTest {
+    @Test
+    void 모임_게시글을_생성한다() {
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청1);
+        //when
+        ExtractableResponse<Response> 모임_게시글_생성 = 모임_게시글_생성(accessToken, 모임_게시글_요청1, 1L);
+        //then
+        assertAll(
+                () -> assertThat(모임_게시글_생성.statusCode()).isEqualTo(200),
+                () -> assertThat(모임_게시글_생성.body().jsonPath().getLong("id")).isNotNull()
+        );
+    }
+
+    @Test
+    void 모임_게시글을_조회한다() {
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청1);
+
+        모임_게시글_생성(accessToken, 모임_게시글_요청1, 1L);
+        //when
+        ExtractableResponse<Response> 모임_게시글_조회 = 모임_게시글_조회(accessToken,1L, 1L);
+        //then
+        assertAll(
+                () -> assertThat(모임_게시글_조회.statusCode()).isEqualTo(200),
+                () -> assertThat(모임_게시글_조회.body().jsonPath().getLong("id")).isNotNull()
+        );
+    }
+
+    @Test
+    void 모임_게시글을_모두_조회한다() {
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청1);
+
+        모임_게시글_생성(accessToken, 모임_게시글_요청1, 1L);
+        //when
+        ExtractableResponse<Response> 모임_게시글_모두_조회 = 모임_게시글_모두_조회(accessToken, 1L);
+        //then
+        assertAll(
+                () -> assertThat(모임_게시글_모두_조회.statusCode()).isEqualTo(200),
+                () -> assertThat(모임_게시글_모두_조회.body().jsonPath().getList("id").size()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 모임_게시글을_삭제한다() {
+        //given
+        String accessToken = getAccessToken();
+
+        모임_생성(accessToken, 모임_요청1);
+
+        모임_게시글_생성(accessToken, 모임_게시글_요청1, 1L);
+        //when
+        ExtractableResponse<Response> 모임_게시글_삭제 = 모임_게시글_삭제(accessToken, 1L, 1L);
+        //then
+        assertThat(모임_게시글_삭제.statusCode()).isEqualTo(204);
+    }
+
+}

--- a/src/test/java/com/capstone/wanf/club/domain/entity/ClubPostTest.java
+++ b/src/test/java/com/capstone/wanf/club/domain/entity/ClubPostTest.java
@@ -1,0 +1,23 @@
+package com.capstone.wanf.club.domain.entity;
+
+import com.capstone.wanf.club.dto.response.ClubPostResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static com.capstone.wanf.fixture.DomainFixture.모임_게시글1;
+import static com.capstone.wanf.fixture.DomainFixture.모임_게시글3;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClubPostTest {
+    @Test
+    void 모임_게시글을_DTO에_담는다(){
+        //when
+        ClubPostResponse clubPostResponse = 모임_게시글3.toResponse();
+        //then
+        assertAll(
+                () -> Assertions.assertThat(clubPostResponse.content()).isEqualTo(모임_게시글1.getContent()),
+                () -> Assertions.assertThat(clubPostResponse.image()).isNull()
+        );
+    }
+
+}

--- a/src/test/java/com/capstone/wanf/club/domain/entity/ClubTest.java
+++ b/src/test/java/com/capstone/wanf/club/domain/entity/ClubTest.java
@@ -1,0 +1,115 @@
+package com.capstone.wanf.club.domain.entity;
+
+import com.capstone.wanf.club.dto.response.ClubDetailResponse;
+import com.capstone.wanf.club.dto.response.ClubResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClubTest {
+    private static final String CLUB_NAME = "clubName";
+
+    private static final int CLUB_MAX_PARTICIPANTS = 10;
+
+    private static final int CURRENT_PARTICIPANTS = 5;
+
+    private static final String CLUB_PASSWORD = "clubPassword";
+
+    private static final boolean RECRUITMENT_STATUS = false;
+
+    @Test
+    void 모임을_생성한다(){
+        //when
+        Club club = Club.builder()
+                .name(CLUB_NAME)
+                .maxParticipants(CLUB_MAX_PARTICIPANTS)
+                .currentParticipants(CURRENT_PARTICIPANTS)
+                .password(CLUB_PASSWORD)
+                .recruitmentStatus(RECRUITMENT_STATUS)
+                .build();
+        //then
+        assertAll(
+                () -> assertEquals(CLUB_NAME, club.getName()),
+                () -> assertEquals(CLUB_MAX_PARTICIPANTS, club.getMaxParticipants()),
+                () -> assertEquals(CURRENT_PARTICIPANTS, club.getCurrentParticipants()),
+                () -> assertEquals(CLUB_PASSWORD, club.getPassword()),
+                () -> assertEquals(club.getPosts().size(), 0),
+                () -> assertEquals(RECRUITMENT_STATUS, club.isRecruitmentStatus())
+        );
+    }
+
+    @Test
+    void 모임의_현재_참여자_수를_증가시킨다(){
+        //given
+        Club club = Club.builder()
+                .name(CLUB_NAME)
+                .maxParticipants(CLUB_MAX_PARTICIPANTS)
+                .currentParticipants(CURRENT_PARTICIPANTS)
+                .password(CLUB_PASSWORD)
+                .recruitmentStatus(RECRUITMENT_STATUS)
+                .build();
+        //when
+        club.updateCurrentParticipants();
+        //then
+        assertEquals(CURRENT_PARTICIPANTS + 1, club.getCurrentParticipants());
+    }
+
+    @Test
+    void 모임의_모집_상태를_변경한다(){
+        //given
+        Club club = Club.builder()
+                .name(CLUB_NAME)
+                .maxParticipants(CLUB_MAX_PARTICIPANTS)
+                .currentParticipants(CURRENT_PARTICIPANTS)
+                .password(CLUB_PASSWORD)
+                .recruitmentStatus(RECRUITMENT_STATUS)
+                .build();
+        //when
+        club.updateRecruitmentStatus();
+        //then
+        assertTrue(club.isRecruitmentStatus());
+    }
+
+    @Test
+    void 모임을_ClubResponse에_담는다(){
+        //given
+        Club club = Club.builder()
+                .id(1L)
+                .name(CLUB_NAME)
+                .maxParticipants(CLUB_MAX_PARTICIPANTS)
+                .currentParticipants(CURRENT_PARTICIPANTS)
+                .password(CLUB_PASSWORD)
+                .recruitmentStatus(RECRUITMENT_STATUS)
+                .build();
+        //when
+        ClubResponse clubResponse = club.toResponse();
+        //then
+        assertAll(
+                () -> assertEquals(club.getId(), clubResponse.id()),
+                () -> assertEquals(club.getName(), clubResponse.name())
+        );
+    }
+
+    @Test
+    void 모임을_ClubDetailResponse에_담는다(){
+        //given
+        Club club = Club.builder()
+                .id(1L)
+                .name(CLUB_NAME)
+                .maxParticipants(CLUB_MAX_PARTICIPANTS)
+                .currentParticipants(CURRENT_PARTICIPANTS)
+                .password(CLUB_PASSWORD)
+                .recruitmentStatus(RECRUITMENT_STATUS)
+                .build();
+        //when
+        ClubDetailResponse detailResponse = club.toDetailResponse();
+        //then
+        assertAll(
+                () -> assertEquals(club.getId(), detailResponse.id()),
+                () -> assertEquals(club.getName(), detailResponse.name()),
+                () -> assertEquals(club.getMaxParticipants(), detailResponse.maxParticipants()),
+                () -> assertEquals(club.getCurrentParticipants(), detailResponse.currentParticipants()),
+                () -> assertEquals(club.isRecruitmentStatus(), detailResponse.recruitmentStatus())
+        );
+    }
+}

--- a/src/test/java/com/capstone/wanf/club/service/ClubPostServiceTest.java
+++ b/src/test/java/com/capstone/wanf/club/service/ClubPostServiceTest.java
@@ -1,0 +1,124 @@
+package com.capstone.wanf.club.service;
+
+import com.capstone.wanf.club.domain.entity.ClubPost;
+import com.capstone.wanf.club.domain.repo.ClubAuthRepository;
+import com.capstone.wanf.club.dto.response.ClubPostResponse;
+import com.capstone.wanf.error.exception.RestApiException;
+import com.capstone.wanf.profile.service.ProfileService;
+import com.capstone.wanf.storage.service.S3Service;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.capstone.wanf.fixture.DomainFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubPostServiceTest {
+    @InjectMocks
+    private ClubPostService clubPostService;
+
+    @Mock
+    private ProfileService profileService;
+
+    @Mock
+    private ClubService clubService;
+
+    @Mock
+    private ClubAuthService clubAuthService;
+
+    @Mock
+    private ClubAuthRepository clubAuthRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Test
+    void 모든_모임_게시글을_조회한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임2);
+        //when
+        List<ClubPostResponse> clubPosts = clubPostService.findAll(모임2.getId(), 유저1);
+        //then
+        assertThat(clubPosts.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 이미지_없는_모임_게시글을_저장한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임1);
+
+        given(profileService.findByUser(any())).willReturn(프로필1);
+        //when
+        ClubPost clubPost = clubPostService.save(유저1, 모임1.getId(), 모임_게시글_요청1);
+        //then
+        assertThat(clubPost.getContent()).isEqualTo(모임_게시글_요청1.content());
+    }
+
+    @Test
+    void 이미지_있는_모임_게시글을_저장한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임1);
+
+        given(profileService.findByUser(any())).willReturn(프로필1);
+
+        given(s3Service.findById(any())).willReturn(이미지1);
+        //when
+        ClubPost clubPost = clubPostService.save(유저1, 모임1.getId(), 모임_게시글_요청2);
+        //then
+        assertThat(clubPost.getContent()).isEqualTo(모임_게시글_요청2.content());
+
+        assertThat(clubPost.getImage()).isEqualTo(이미지1);
+    }
+
+    @Test
+    void 모임_게시글을_삭제한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임2);
+
+        given(profileService.findByUser(any())).willReturn(프로필1);
+        //when
+        List<ClubPost> clubPosts  = clubPostService.delete(유저1, 모임2.getId(), 모임_게시글1.getId());
+        //then
+        assertThat(clubPosts.size()).isEqualTo(0);
+    }
+
+    @Test
+    void 게시글_작성자가_아닌_사용자가_모임_게시글을_삭제할_수_없다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임3);
+
+        given(profileService.findByUser(any())).willReturn(프로필2);
+        //when & then
+        assertThatThrownBy(() -> clubPostService.delete(유저2, 모임3.getId(), 모임_게시글1.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 이미지가_있는_게시물이며_이미지도_삭제한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임3);
+
+        given(profileService.findByUser(any())).willReturn(프로필1);
+        //when
+        List<ClubPost> clubPosts  = clubPostService.delete(유저1, 모임3.getId(), 모임_게시글2.getId());
+        //then
+        assertThat(clubPosts.size()).isEqualTo(1);
+    }
+
+    @Test
+    void ID에_해당하는_모임_게시글을_조회한다(){
+        //given
+        given(clubService.findById(any())).willReturn(모임3);
+        //when
+        ClubPost clubPost = clubPostService.findById(모임3.getId(), 모임_게시글1.getId());
+        //then
+        assertThat(clubPost).isEqualTo(모임_게시글1);
+    }
+}

--- a/src/test/java/com/capstone/wanf/club/service/ClubServiceAuthTest.java
+++ b/src/test/java/com/capstone/wanf/club/service/ClubServiceAuthTest.java
@@ -1,0 +1,86 @@
+package com.capstone.wanf.club.service;
+
+import com.capstone.wanf.club.domain.entity.Authority;
+import com.capstone.wanf.club.domain.entity.ClubAuth;
+import com.capstone.wanf.club.domain.repo.ClubAuthRepository;
+import com.capstone.wanf.club.dto.response.ClubResponse;
+import com.capstone.wanf.error.exception.RestApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.capstone.wanf.fixture.DomainFixture.*;
+import static com.capstone.wanf.fixture.DomainFixture.유저1;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceAuthTest {
+    @InjectMocks
+    private ClubAuthService clubAuthService;
+
+    @Mock
+    private ClubAuthRepository clubAuthRepository;
+
+    @Test
+    void 모임_권한을_저장한다(){
+        //when
+        clubAuthService.grantAuthorityToClub(유저1, 모임1, Authority.CLUB_LEADER);
+        //then
+        then(clubAuthRepository).should(times(1)).save(any(ClubAuth.class));
+    }
+
+    @Test
+    void 모임_권한을_검색한다(){
+        //given
+        given(clubAuthRepository.findByUserId(any())).willReturn(List.of(리더모임권한1));
+        //when
+        List<ClubResponse> 유저권한 = clubAuthService.findByUserId(유저1.getId());
+        //then
+        assertThat(유저권한).isEqualTo(List.of(모임1.toResponse()));
+    }
+
+    @Test
+    void 해당_모임의_권한이_없는_유저(){
+        //given
+        given(clubAuthRepository.findByUserIdAndClubId(any(), any())).willReturn(Optional.empty());
+        //when
+        Authority 유저권한 = clubAuthService.findByUserIdAndClubId(유저1.getId(), 모임1.getId());
+        //then
+        assertThat(유저권한).isEqualTo(Authority.NONE);
+    }
+
+    @Test
+    void 유저의_해당_모임_권한_확인(){
+        //given
+        given(clubAuthRepository.findByUserIdAndClubId(any(), any())).willReturn(Optional.of(리더모임권한1));
+        //when
+        Authority 유저권한 = clubAuthService.findByUserIdAndClubId(유저1.getId(), 모임1.getId());
+        //then
+        assertThat(유저권한).isEqualTo(Authority.CLUB_LEADER);
+    }
+
+    @Test
+    void 모임에_대한_권한이_없으면_예외가_발생한다(){
+        //given
+        given(clubAuthRepository.findByUserIdAndClubId(any(), any())).willReturn(Optional.empty());
+        //when & then
+        assertThatThrownBy(() -> clubAuthService.getAuthority(유저1.getId(), 모임1.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 모임에_대한_사용자의_권한을_반환한다(){
+        //given
+        given(clubAuthRepository.findByUserIdAndClubId(any(), any())).willReturn(Optional.of(리더모임권한1));
+        //when
+        Authority 유저권한 = clubAuthService.getAuthority(유저1.getId(), 모임1.getId());
+        //then
+        assertThat(유저권한).isEqualTo(Authority.CLUB_LEADER);
+    }
+}

--- a/src/test/java/com/capstone/wanf/club/service/ClubServiceTest.java
+++ b/src/test/java/com/capstone/wanf/club/service/ClubServiceTest.java
@@ -1,0 +1,137 @@
+package com.capstone.wanf.club.service;
+
+import com.capstone.wanf.club.domain.entity.Authority;
+import com.capstone.wanf.club.domain.entity.Club;
+import com.capstone.wanf.club.domain.repo.ClubRepository;
+import com.capstone.wanf.club.dto.request.ClubPwdRequest;
+import com.capstone.wanf.error.exception.RestApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.capstone.wanf.fixture.DomainFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceTest {
+    @InjectMocks
+    private ClubService clubService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubAuthService clubAuthService;
+
+    @Test
+    void 모임을_모두_조회한다(){
+        //given
+        given(clubRepository.findAll()).willReturn(List.of(모임1, 모임2));
+        //when
+        List<Club> clubs = clubService.findAll();
+        //then
+        assertThat(clubs.size()).isEqualTo(2);
+    }
+
+    @Test
+    void ID에_해당하는_모임을_조회한다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임1));
+        //when
+        Club club = clubService.findById(모임1.getId());
+        //then
+        assertThat(club.getId()).isEqualTo(모임1.getId());
+    }
+
+    @Test
+    void 해당하는_모임이_존재하지_않으면_예외를_던진다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.empty());
+        //when & then
+        assertThatThrownBy(() -> clubService.findById(모임1.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 모임에_가입한다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임1));
+
+        given(clubAuthService.findByUserIdAndClubId(any(), any())).willReturn(Authority.NONE);
+        //when
+        clubService.joinClub(유저1, 모임_비밀번호_요청1);
+        //then
+        then(clubAuthService).should(times(1)).grantAuthorityToClub(유저1, 모임1, Authority.CLUB_MEMBER);
+    }
+
+    @Test
+    void 이미_해당_모임에_가입되어_있으면_예외를_던진다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임1));
+
+        given(clubAuthService.findByUserIdAndClubId(any(), any())).willReturn(Authority.CLUB_LEADER);
+        //when & then
+        assertThatThrownBy(() -> clubService.joinClub(유저1, 모임_비밀번호_요청1))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 해당_모임의_인원이_다_찼을_경우_예외를_던진다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임3));
+
+        given(clubAuthService.findByUserIdAndClubId(any(), any())).willReturn(Authority.NONE);
+        //when & then
+        assertThatThrownBy(() -> clubService.joinClub(유저1, 모임_비밀번호_요청1))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 비밀번호가_틀리다면_예외를_던진다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임2));
+
+        given(clubAuthService.findByUserIdAndClubId(any(), any())).willReturn(Authority.NONE);
+        //when & then
+        assertThatThrownBy(() -> clubService.joinClub(유저1, 모임_비밀번호_요청1))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 모임을_생성한다(){
+        //given
+        given(clubRepository.save(any())).willReturn(모임1);
+        //when
+        Club club = clubService.save(모임_요청1, 유저1);
+        //then
+        assertThat(club.getId()).isEqualTo(모임1.getId());
+    }
+
+    @Test
+    void 모임_권한을_확인한다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임1));
+
+        given(clubAuthService.getAuthority(any(), any())).willReturn(Authority.CLUB_LEADER);
+        //when
+        Authority authority = clubService.checkAuthority(모임1.getId(), 유저1);
+        //then
+        assertThat(authority).isEqualTo(Authority.CLUB_LEADER);
+    }
+
+    @Test
+    void 모임_비밀번호를_조회한다(){
+        //given
+        given(clubRepository.findById(any())).willReturn(Optional.of(모임1));
+        //when
+        ClubPwdRequest password = clubService.getPassword(모임1.getId());
+        //then
+        assertThat(password.password()).isEqualTo(모임1.getPassword());
+    }
+}

--- a/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
+++ b/src/test/java/com/capstone/wanf/fixture/DomainFixture.java
@@ -1,5 +1,12 @@
 package com.capstone.wanf.fixture;
 
+import com.capstone.wanf.club.domain.entity.Authority;
+import com.capstone.wanf.club.domain.entity.Club;
+import com.capstone.wanf.club.domain.entity.ClubAuth;
+import com.capstone.wanf.club.domain.entity.ClubPost;
+import com.capstone.wanf.club.dto.request.ClubPostRequest;
+import com.capstone.wanf.club.dto.request.ClubPwdRequest;
+import com.capstone.wanf.club.dto.request.ClubRequest;
 import com.capstone.wanf.comment.domain.entity.Comment;
 import com.capstone.wanf.comment.dto.request.CommentRequest;
 import com.capstone.wanf.course.domain.entity.Course;
@@ -26,6 +33,7 @@ import com.capstone.wanf.user.dto.request.UserRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class DomainFixture {
@@ -263,7 +271,7 @@ public class DomainFixture {
             .course(강의1)
             .category(Category.friend)
             .profile(프로필1)
-            .comments(new ArrayList<>(Arrays.asList(댓글1)))
+            .comments(new ArrayList<>(Collections.singletonList(댓글1)))
             .build();
 
     public static final Post 게시글4 = Post.builder()
@@ -338,4 +346,95 @@ public class DomainFixture {
             .build();
 
     public static final List<MessageResponse> 쪽지_목록1 = List.of(쪽지_응답1, 쪽지_응답2);
+
+    public static final ClubPost 모임_게시글1 = ClubPost.builder()
+            .id(1L)
+            .image(이미지1)
+            .content("모임_게시글1")
+            .profile(프로필1)
+            .build();
+
+    public static final ClubPost 모임_게시글2 = ClubPost.builder()
+            .id(2L)
+            .content("모임_게시글1")
+            .profile(프로필1)
+            .image(이미지2)
+            .build();
+
+    public static final ClubPost 모임_게시글3 = ClubPost.builder()
+            .id(3L)
+            .content("모임_게시글1")
+            .profile(프로필1)
+            .build();
+
+    public static final Club 모임1 = Club.builder()
+            .id(1L)
+            .name("클럽1")
+            .password("1234")
+            .maxParticipants(5)
+            .currentParticipants(4)
+            .recruitmentStatus(false)
+            .build();
+
+    public static final Club 모임2 = Club.builder()
+            .id(1L)
+            .name("클럽1")
+            .password("0000")
+            .maxParticipants(10)
+            .currentParticipants(1)
+            .recruitmentStatus(false)
+            .posts(new ArrayList<>(List.of(모임_게시글1)))
+            .build();
+
+    public static final Club 모임3 = Club.builder()
+            .id(1L)
+            .name("클럽1")
+            .maxParticipants(3)
+            .currentParticipants(3)
+            .recruitmentStatus(true)
+            .posts(new ArrayList<>(List.of(모임_게시글1, 모임_게시글2)))
+            .build();
+
+    public static final ClubAuth 리더모임권한1 = ClubAuth.builder()
+            .user(유저1)
+            .club(모임1)
+            .authority(Authority.CLUB_LEADER)
+            .build();
+
+    public static final ClubAuth 모임권한없음1 = ClubAuth.builder()
+            .user(유저2)
+            .club(모임1)
+            .authority(Authority.NONE)
+            .build();
+
+    public static final ClubPostRequest 모임_게시글_요청1 = ClubPostRequest
+            .builder()
+            .content("모임_게시글_요청1")
+            .build();
+
+    public static final ClubPostRequest 모임_게시글_요청2 = ClubPostRequest
+            .builder()
+            .content("모임_게시글_요청2")
+            .imageId(1L)
+            .build();
+
+    public static final ClubPwdRequest 모임_비밀번호_요청1 = ClubPwdRequest
+            .builder()
+            .clubId(1L)
+            .password("1234")
+            .build();
+
+    public static final ClubRequest 모임_요청1 = ClubRequest
+            .builder()
+            .name("모임_요청1")
+            .maxParticipants(1)
+            .password("1234")
+            .build();
+
+    public static final ClubRequest 모임_요청2 = ClubRequest
+            .builder()
+            .name("모임_요청2")
+            .maxParticipants(5)
+            .password("1234")
+            .build();
 }


### PR DESCRIPTION
issue No: #119 
* 모임, 모임 게시글에 대한 계층별 테스트 추가
* auth 부분은 테스트 대상에서 제외
* 모임, 모임 게시글 부분 리펙토링 진행 - 메소드 분리 및 어노테이션 추가(@Builder), 
* 현재 테스트 커버리지 : 92%( auth 부분 제외한 값)