### PR TITLE
쪽지를 주고받은 사용자의 프로필 조회 로직 수정

### DIFF
--- a/src/main/java/com/capstone/wanf/message/controller/MessageConsumerController.java
+++ b/src/main/java/com/capstone/wanf/message/controller/MessageConsumerController.java
@@ -34,7 +34,7 @@ public class MessageConsumerController {
     @GetMapping("/messages/senders")
     @Operation(summary = "쪽지를 주고 받은 사람들을 조회합니다. 최근에 쪽지를 주고 받은 순으로 정렬되어 있습니다.")
     public ResponseEntity<List<ProfileResponse>> getSenders(@CurrentUser User user) {
-        List<ProfileResponse> message = messageConsumerService.getSenders(user);
+        List<ProfileResponse> message = messageConsumerService.getMessagingPartners(user);
 
         return ResponseEntity.ok(message);
     }

--- a/src/main/java/com/capstone/wanf/message/dto/response/ReceiverMessageResponse.java
+++ b/src/main/java/com/capstone/wanf/message/dto/response/ReceiverMessageResponse.java
@@ -9,13 +9,13 @@ import java.util.List;
 @Schema(description = "송신자와 수신자 간의 쪽지 응답 데이터")
 public record ReceiverMessageResponse(
         @Schema(description = "나의 프로필 id")
-        Long receiverProfileId,
+        Long myProfileId,
         @Schema(description = "송신자가 보낸 쪽지들")
         List<MessageResponse> messages
 ) {
         public static ReceiverMessageResponse of(Long myProfileId, List<MessageResponse> messages) {
                 return ReceiverMessageResponse.builder()
-                        .receiverProfileId(myProfileId)
+                        .myProfileId(myProfileId)
                         .messages(messages)
                         .build();
         }

--- a/src/main/java/com/capstone/wanf/message/service/MessageConsumerService.java
+++ b/src/main/java/com/capstone/wanf/message/service/MessageConsumerService.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class MessageConsumerService {
+public class  MessageConsumerService {
     private final MessageRepository messageRepository;
 
     private final MessageConverter messageConverter;
@@ -54,10 +54,10 @@ public class MessageConsumerService {
         return ReceiverMessageResponse.of(receiverProfile.getId(), messages);
     }
 
-    public List<ProfileResponse> getSenders(User user) {
-        Profile receiverProfile = profileService.findByUser(user);
+    public List<ProfileResponse> getMessagingPartners(User user) {
+        Profile myProfile = profileService.findByUser(user);
 
-        return messageRepositorySupport.findSenderByReceiver(receiverProfile).stream()
+        return messageRepositorySupport.findInteractedProfiles(myProfile).stream()
                 .map(ProfileResponse::of)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/capstone/wanf/message/service/MessageServiceTest.java
+++ b/src/test/java/com/capstone/wanf/message/service/MessageServiceTest.java
@@ -82,7 +82,7 @@ public class MessageServiceTest {
         ReceiverMessageResponse 수신자_쪽지_응답_목록 = messageConsumerService.getMessage(유저1, 1L);
         //then
         assertAll(
-                () -> assertThat(수신자_쪽지_응답_목록.receiverProfileId()).isEqualTo(프로필2.getId()),
+                () -> assertThat(수신자_쪽지_응답_목록.myProfileId()).isEqualTo(프로필2.getId()),
                 () -> assertThat(수신자_쪽지_응답_목록.messages()).isEqualTo(쪽지_목록1)
         );
     }
@@ -92,9 +92,9 @@ public class MessageServiceTest {
         //given
         given(profileService.findByUser(any())).willReturn(프로필1);
 
-        given(messageRepositorySupport.findSenderByReceiver(any())).willReturn(List.of(프로필1));
+        given(messageRepositorySupport.findInteractedProfiles(any())).willReturn(List.of(프로필1));
         //when
-        List<ProfileResponse> 쪽지를_주고받은_사람들 = messageConsumerService.getSenders(유저1);
+        List<ProfileResponse> 쪽지를_주고받은_사람들 = messageConsumerService.getMessagingPartners(유저1);
         //then
         assertThat(쪽지를_주고받은_사람들.size()).isEqualTo(1);
     }


### PR DESCRIPTION
* issue No: #124 
* 기존에는 message의 receiver가 나라면 그 sender의 프로필만 조회하였는데 이렇게 되면 내가 처음으로 메시지를 보낸 사용자는 쪽지 목록에 뜨지 않는 오류가 발생하였다.
* 그래서 message의 receiver가 나거나 sender가 나인 message를 모두 조회하여 나와 쪽지를 주고 받은 모든 사용자의 프로필을 조회하도록 로직을 수정했다.